### PR TITLE
Disabling Logging by default and fixing null pointer

### DIFF
--- a/SchanaModParty/Game/schana_party_manager_server.c
+++ b/SchanaModParty/Game/schana_party_manager_server.c
@@ -280,8 +280,13 @@ class SchanaPartyManagerServer {
 		auto all_player_ids = new ref array<string>;
 		auto all_player_names = new ref array<string>;
 		foreach (auto player_id, auto player_base_player : id_map) {
-			all_player_ids.Insert (player_id);
-			all_player_names.Insert (player_base_player.GetIdentity ().GetName ());
+			if (player_base_player){
+				PlayerIdentity theIdentity = PlayerIdentity.Cast (player_base_player.GetIdentity ());
+				if (theIdentity){
+					all_player_ids.Insert (player_id);
+					all_player_names.Insert (theIdentity.GetName ());
+				}
+			}
 		}
 
 		auto all_player_info = new ref Param2<ref array<string>, ref array<string>> (all_player_ids, all_player_names);

--- a/SchanaModParty/Game/schana_party_server_settings.c
+++ b/SchanaModParty/Game/schana_party_server_settings.c
@@ -2,13 +2,13 @@ class SchanaModPartyServerSettings {
     private static string DIR = "$profile:SchanaModParty";
     private static string PATH = DIR + "\\server-config.json";
 
-    private static const int DEFAULT_LOG_FREQUENCY = 10;
-    private static const int DEFAULT_VERBOSITY = 1;
+    private static const int DEFAULT_LOG_FREQUENCY = -1;
+    private static const int DEFAULT_VERBOSITY = -1;
     private static const int DEFAULT_MAX_PARTY_SIZE = -1;
     private static const int DEFAULT_SEND_INFO_FREQUENCY = 2;
     private static const int DEFAULT_SEND_MARKER_FREQUENCY = 2;
     private static const int DEFAULT_MAX_MARKERS = 10;
-    private static const int DEFAULT_MAX_PARTY_REFRESH_RATE = 5;
+    private static const int DEFAULT_MAX_PARTY_REFRESH_RATE = 4;
 
     private int logPartiesFrequencySeconds = DEFAULT_LOG_FREQUENCY;
     private int verbosity = DEFAULT_VERBOSITY;


### PR DESCRIPTION
Fixing a null pointer(possible crash)
Changed logging to be disabled to ensure its not causing crashes any servers with logging disabled aren't getting crashes I think it might be related to string size of the log parties function